### PR TITLE
Fix winner rainbow animation being overridden on immediate correct answer

### DIFF
--- a/include/client_manager.h
+++ b/include/client_manager.h
@@ -18,6 +18,7 @@ public:
   
 private:
   ClientData data;
+  uint32_t celebrateUntilMs;
   
 public:
   ClientManager();
@@ -25,6 +26,7 @@ public:
   // State management
   void setState(ClientState newState);
   ClientState getState() const;
+  bool isCelebrateLocked() const;
   void handleStateAnimations();
   
   // Assignment handling

--- a/src/client_manager.cpp
+++ b/src/client_manager.cpp
@@ -14,6 +14,7 @@ ClientManager::ClientManager() {
   data.assignedColor = Rgb(255, 0, 0); // Default red
   data.hasBuzzed = false;
   data.isActive = false;
+  celebrateUntilMs = 0;
   
   if (clientMqtt) {
     data.id = clientMqtt->getClientId();
@@ -21,6 +22,15 @@ ClientManager::ClientManager() {
 }
 
 void ClientManager::setState(ClientState newState) {
+  // Keep CELEBRATE stable for its full duration.
+  if (isCelebrateLocked() && newState != ClientState::CELEBRATE) {
+    return;
+  }
+
+  if (newState == ClientState::CELEBRATE) {
+    celebrateUntilMs = millis() + CELEBRATION_DURATION_MS;
+  }
+
   if (data.currentState != newState) {
     Serial.printf("State change: %d -> %d\n", (int)data.currentState, (int)newState);
     data.currentState = newState;
@@ -30,6 +40,11 @@ void ClientManager::setState(ClientState newState) {
 ClientState ClientManager::getState() const {
   return data.currentState;
 }
+
+bool ClientManager::isCelebrateLocked() const {
+  return data.currentState == ClientState::CELEBRATE && millis() < celebrateUntilMs;
+}
+
 
 void ClientManager::handleStateAnimations() {
   if (!clientLedController) return;
@@ -82,14 +97,9 @@ void ClientManager::handleStateAnimations() {
       
     case ClientState::CELEBRATE:
       clientLedController->animateCelebration();
-      // Auto-return to idle after celebration
-      static uint32_t celebrationStart = 0;
-      if (celebrationStart == 0) {
-        celebrationStart = millis();
-      }
-      if (millis() - celebrationStart > CELEBRATION_DURATION_MS) {
+      // Auto-return to idle after fixed celebration window
+      if (!isCelebrateLocked()) {
         setState(ClientState::IDLE);
-        celebrationStart = 0; // Reset for next time
       }
       break;
       

--- a/src/client_mqtt.cpp
+++ b/src/client_mqtt.cpp
@@ -230,7 +230,9 @@ void handleGameState(const String& payload) {
     // New question, reset buzz state
     if (clientManager) {
       clientManager->resetBuzzState();
-      clientManager->setState(ClientState::IDLE);
+      if (!clientManager->isCelebrateLocked()) {
+        clientManager->setState(ClientState::IDLE);
+      }
     }
   }
 }


### PR DESCRIPTION
**PR Description:**
Related issue: https://github.com/Boergi/ESP-Quiz-Buzzer/issues/2

**Problem:**
In some cases, the winner animation (rainbow ring) was immediately overridden after being triggered.
Instead, the normal loser/pulsing animation appeared shortly after.

**Steps to Reproduce:**
A question is displayed.
A client buzzes.
The answer is marked correct immediately.
Expected Behavior
The winner receives the rainbow animation and keeps it for the intended duration.

**Actual Behavior (before):**
The rainbow ring appears only briefly (~0.5s) and is then replaced by the pulsing/loser animation.

**Root Cause:**
CELEBRATE could be overwritten immediately by subsequent state updates (especially READY -> IDLE).

**Fix:**
Added a timed CELEBRATE lock window on the client.
While the lock is active, competing state transitions are ignored.
In READY handling, IDLE is set only if no CELEBRATE lock is active.
After the lock duration ends, state returns to IDLE as intended.

**Files Changed:**
[client_manager.h](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/krets/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
[client_manager.cpp](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/krets/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)
[client_mqtt.cpp](https://file+.vscode-resource.vscode-cdn.net/c%3A/Users/krets/.vscode/extensions/openai.chatgpt-0.4.71-win32-x64/webview/#)

**Validation:**
Client build passes (platformio run -e client).
The fast path (“buzz + immediate correct answer”) now keeps rainbow animation for the full duration.