### PR TITLE
Add battery level display on long press for server and client

### DIFF
--- a/include/client_manager.h
+++ b/include/client_manager.h
@@ -47,12 +47,13 @@ class ClientButtonHandler {
 private:
   Bounce& button;
   uint32_t lastButtonPress;
-  bool buttonPressed;
+  bool buttonHeld;
+  bool veryLongTriggered;
   
 public:
   ClientButtonHandler(Bounce& btn);
   void update();
-  bool wasPressed();
+  ButtonPress getButtonPress();
 };
 
 // Global instances

--- a/include/client_mqtt.h
+++ b/include/client_mqtt.h
@@ -50,3 +50,4 @@ void handleCommand(const String& payload);
 
 // Global MQTT client instance
 extern ClientMQTT* clientMqtt;
+extern Phase currentGamePhase;

--- a/include/game_manager.h
+++ b/include/game_manager.h
@@ -10,6 +10,7 @@ private:
   Bounce& button;
   uint32_t lastButtonPress;
   bool buttonHeld;
+  bool longTriggered;
   
 public:
   ButtonHandler(Bounce& btn);

--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -128,7 +128,7 @@ void setup() {
   Serial.println("Client ready!");
   Serial.println("Button Controls:");
   Serial.println("- SHORT press: Buzz (when connected and game is open)");
-  Serial.println("- VERY LONG press: Battery check (when disconnected)");
+  Serial.println("- VERY LONG press: Battery check (when not connected or in LOBBY)");
   Serial.println("- System automatically handles connection and state changes");
 }
 
@@ -177,7 +177,8 @@ void loop() {
         }
       } else if (press == ButtonPress::VERY_LONG) {
         const bool notConnected = !(clientMqtt && clientMqtt->isConnected());
-        const bool batteryCheckAllowed = notConnected;
+        const bool inLobby = (currentGamePhase == Phase::LOBBY);
+        const bool batteryCheckAllowed = notConnected || inLobby;
 
         if (batteryCheckAllowed) {
           const float vbat = readBatteryVoltage();
@@ -188,7 +189,7 @@ void loop() {
           batteryDisplayActive = true;
           batteryDisplayUntil = millis() + BATTERY_DISPLAY_MS;
         } else {
-          Serial.println("Battery check ignored (only allowed when disconnected)");
+          Serial.println("Battery check ignored (only allowed when disconnected or LOBBY)");
         }
       }
     }

--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -46,7 +46,7 @@ float readBatteryVoltage() {
 
 uint8_t batteryPercentFromVoltage(float vbat) {
   if (vbat >= BATTERY_TABLE[0].voltage) return 100;
-  if (vbat <= BATTERY_TABLE[10].voltage) return 0;
+  if (vbat <= BATTERY_TABLE[10].voltage) return 1;
 
   for (uint8_t i = 0; i < 10; i++) {
     const BatteryPoint high = BATTERY_TABLE[i];
@@ -56,7 +56,7 @@ uint8_t batteryPercentFromVoltage(float vbat) {
       return static_cast<uint8_t>(low.percent + t * (high.percent - low.percent));
     }
   }
-  return 0;
+  return 1;
 }
 
 Rgb batteryColor(uint8_t percent) {
@@ -128,7 +128,7 @@ void setup() {
   Serial.println("Client ready!");
   Serial.println("Button Controls:");
   Serial.println("- SHORT press: Buzz (when connected and game is open)");
-  Serial.println("- VERY LONG press: Battery check (when not connected or in LOBBY)");
+  Serial.println("- VERY LONG press: Battery check (when disconnected)");
   Serial.println("- System automatically handles connection and state changes");
 }
 
@@ -177,8 +177,7 @@ void loop() {
         }
       } else if (press == ButtonPress::VERY_LONG) {
         const bool notConnected = !(clientMqtt && clientMqtt->isConnected());
-        const bool inLobby = (currentGamePhase == Phase::LOBBY);
-        const bool batteryCheckAllowed = notConnected || inLobby;
+        const bool batteryCheckAllowed = notConnected;
 
         if (batteryCheckAllowed) {
           const float vbat = readBatteryVoltage();
@@ -189,7 +188,7 @@ void loop() {
           batteryDisplayActive = true;
           batteryDisplayUntil = millis() + BATTERY_DISPLAY_MS;
         } else {
-          Serial.println("Battery check ignored (only allowed when disconnected or LOBBY)");
+          Serial.println("Battery check ignored (only allowed when disconnected)");
         }
       }
     }

--- a/src/client_main.cpp
+++ b/src/client_main.cpp
@@ -13,6 +13,80 @@
 Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 Bounce button = Bounce();
 
+namespace {
+struct BatteryPoint {
+  float voltage;
+  uint8_t percent;
+};
+
+constexpr uint8_t BATTERY_ADC_PIN = 34;
+constexpr float BATTERY_DIVIDER_R1_OHM = 100000.0f; // BAT+ -> ADC
+constexpr float BATTERY_DIVIDER_R2_OHM = 100000.0f; // ADC -> GND
+constexpr uint8_t BATTERY_SAMPLE_COUNT = 16;
+constexpr uint16_t BATTERY_DISPLAY_MS = 3000;
+
+constexpr BatteryPoint BATTERY_TABLE[] = {
+  {4.20f, 100}, {4.10f, 90}, {4.00f, 80}, {3.92f, 70}, {3.85f, 60},
+  {3.79f, 50},  {3.73f, 40}, {3.68f, 30}, {3.60f, 20}, {3.45f, 10}, {3.30f, 0}
+};
+
+bool batteryDisplayActive = false;
+uint32_t batteryDisplayUntil = 0;
+
+float readBatteryVoltage() {
+  uint32_t sumMilliVolts = 0;
+  for (uint8_t i = 0; i < BATTERY_SAMPLE_COUNT; i++) {
+    sumMilliVolts += analogReadMilliVolts(BATTERY_ADC_PIN);
+    delay(2);
+  }
+
+  const float adcVolts = (sumMilliVolts / static_cast<float>(BATTERY_SAMPLE_COUNT)) / 1000.0f;
+  return adcVolts * ((BATTERY_DIVIDER_R1_OHM + BATTERY_DIVIDER_R2_OHM) / BATTERY_DIVIDER_R2_OHM);
+}
+
+uint8_t batteryPercentFromVoltage(float vbat) {
+  if (vbat >= BATTERY_TABLE[0].voltage) return 100;
+  if (vbat <= BATTERY_TABLE[10].voltage) return 0;
+
+  for (uint8_t i = 0; i < 10; i++) {
+    const BatteryPoint high = BATTERY_TABLE[i];
+    const BatteryPoint low = BATTERY_TABLE[i + 1];
+    if (vbat <= high.voltage && vbat >= low.voltage) {
+      const float t = (vbat - low.voltage) / (high.voltage - low.voltage);
+      return static_cast<uint8_t>(low.percent + t * (high.percent - low.percent));
+    }
+  }
+  return 0;
+}
+
+Rgb batteryColor(uint8_t percent) {
+  if (percent < 20) return Rgb(255, 0, 0);
+  if (percent < 50) return Rgb(255, 180, 0);
+  return Rgb(0, 255, 0);
+}
+
+void renderBatteryRing(uint8_t percent) {
+  const Rgb base = batteryColor(percent);
+  const float ledUnits = (percent / 100.0f) * LED_COUNT;
+  const uint8_t fullLeds = static_cast<uint8_t>(ledUnits);
+  const float fraction = ledUnits - fullLeds;
+
+  for (uint8_t i = 0; i < LED_COUNT; i++) {
+    if (i < fullLeds) {
+      clientLedController->setPixelColor(i, base);
+    } else if (i == fullLeds && fraction > 0.0f) {
+      clientLedController->setPixelColor(i, Rgb(
+        static_cast<uint8_t>(base.r * fraction),
+        static_cast<uint8_t>(base.g * fraction),
+        static_cast<uint8_t>(base.b * fraction)
+      ));
+    } else {
+      clientLedController->setPixelColor(i, COLOR_BLACK);
+    }
+  }
+}
+} // namespace
+
 void setup() {
   Serial.begin(115200);
   Serial.println("ESP32 Quiz-Buzzer Client Starting...");
@@ -24,6 +98,8 @@ void setup() {
   strip.setBrightness(LED_BRIGHTNESS);
   strip.clear();
   strip.show();
+  analogReadResolution(12);
+  analogSetPinAttenuation(BATTERY_ADC_PIN, ADC_11db);
   
   // Initialize LED Controller
   clientLedController = new ClientLEDController(strip);
@@ -51,13 +127,15 @@ void setup() {
   
   Serial.println("Client ready!");
   Serial.println("Button Controls:");
-  Serial.println("- Press: Buzz (when connected and game is open)");
+  Serial.println("- SHORT press: Buzz (when connected and game is open)");
+  Serial.println("- VERY LONG press: Battery check (when not connected or in LOBBY)");
   Serial.println("- System automatically handles connection and state changes");
 }
 
 void loop() {
-  // Handle MQTT communication
-  if (clientMqtt) {
+  // Keep battery indication stable by pausing reconnect attempts.
+  if (!batteryDisplayActive && clientMqtt) {
+    // Handle MQTT communication
     clientMqtt->loop();
     
     // Update client manager state based on connection
@@ -83,22 +161,35 @@ void loop() {
   // Handle button presses
   if (clientButtonHandler) {
     clientButtonHandler->update();
-    
-    if (clientButtonHandler->wasPressed()) {
-      Serial.println("Button pressed!");
-      
-      if (clientManager) {
+    ButtonPress press = clientButtonHandler->getButtonPress();
+    if (press != ButtonPress::NONE && clientManager) {
+      if (press == ButtonPress::SHORT) {
+        Serial.println("Button SHORT press");
         if (clientManager->canBuzz()) {
           clientManager->buzz();
         } else {
           Serial.println("Cannot buzz right now");
-          
-          // Debug info
           Serial.printf("State: %d, Assigned: %s, Buzzed: %s, Connected: %s\n",
                         (int)clientManager->getState(),
                         clientManager->isAssigned() ? "yes" : "no",
                         clientManager->getData().hasBuzzed ? "yes" : "no",
                         (clientMqtt && clientMqtt->isConnected()) ? "yes" : "no");
+        }
+      } else if (press == ButtonPress::VERY_LONG) {
+        const bool notConnected = !(clientMqtt && clientMqtt->isConnected());
+        const bool inLobby = (currentGamePhase == Phase::LOBBY);
+        const bool batteryCheckAllowed = notConnected || inLobby;
+
+        if (batteryCheckAllowed) {
+          const float vbat = readBatteryVoltage();
+          const uint8_t percent = batteryPercentFromVoltage(vbat);
+          Serial.printf("Battery check: %.2fV -> %u%%\n", vbat, percent);
+          renderBatteryRing(percent);
+          strip.show();
+          batteryDisplayActive = true;
+          batteryDisplayUntil = millis() + BATTERY_DISPLAY_MS;
+        } else {
+          Serial.println("Battery check ignored (only allowed when disconnected or LOBBY)");
         }
       }
     }
@@ -106,7 +197,13 @@ void loop() {
   
   // Handle state animations
   if (clientManager) {
-    clientManager->handleStateAnimations();
+    if (batteryDisplayActive) {
+      if (millis() >= batteryDisplayUntil) {
+        batteryDisplayActive = false;
+      }
+    } else {
+      clientManager->handleStateAnimations();
+    }
   }
   
   delay(10); // Small delay for stability

--- a/src/client_manager.cpp
+++ b/src/client_manager.cpp
@@ -168,22 +168,44 @@ const Rgb& ClientManager::getAssignedColor() const {
 }
 
 // ClientButtonHandler Implementation
-ClientButtonHandler::ClientButtonHandler(Bounce& btn) : button(btn), lastButtonPress(0), buttonPressed(false) {
+ClientButtonHandler::ClientButtonHandler(Bounce& btn)
+  : button(btn), lastButtonPress(0), buttonHeld(false), veryLongTriggered(false) {
 }
 
 void ClientButtonHandler::update() {
   button.update();
-  
-  if (button.fell() && !buttonPressed) {
-    buttonPressed = true;
+
+  if (button.fell()) {
     lastButtonPress = millis();
+    buttonHeld = false;
+    veryLongTriggered = false;
   }
 }
 
-bool ClientButtonHandler::wasPressed() {
-  if (buttonPressed) {
-    buttonPressed = false; // Reset flag
-    return true;
+ButtonPress ClientButtonHandler::getButtonPress() {
+  if (button.read() == LOW && lastButtonPress && !veryLongTriggered) {
+    uint32_t holdTime = millis() - lastButtonPress;
+    if (holdTime >= VERY_LONG_PRESS_MS) {
+      veryLongTriggered = true;
+      buttonHeld = true;
+      return ButtonPress::VERY_LONG;
+    }
   }
-  return false;
+
+  if (button.rose()) {
+    if (!buttonHeld && lastButtonPress) {
+      uint32_t pressTime = millis() - lastButtonPress;
+      if (pressTime < SHORT_PRESS_MAX_MS) {
+        lastButtonPress = 0;
+        buttonHeld = false;
+        veryLongTriggered = false;
+        return ButtonPress::SHORT;
+      }
+    }
+    lastButtonPress = 0;
+    buttonHeld = false;
+    veryLongTriggered = false;
+  }
+
+  return ButtonPress::NONE;
 }

--- a/src/client_mqtt.cpp
+++ b/src/client_mqtt.cpp
@@ -4,6 +4,7 @@
 
 // Global instance
 ClientMQTT* clientMqtt = nullptr;
+Phase currentGamePhase = Phase::BOOT;
 bool gameIsOpen = false; // Track if game is in OPEN state
 
 ClientMQTT::ClientMQTT() : mqttClient(wifiClient), connected(false), lastConnectionAttempt(0), lastPing(0) {
@@ -217,6 +218,7 @@ void handleGameState(const String& payload) {
   
   // Handle phase changes
   Phase phase = stringToPhase(phaseStr.c_str());
+  currentGamePhase = phase;
   
   // Update global gameIsOpen state
   gameIsOpen = (phase == Phase::OPEN || phase == Phase::ANSWER);

--- a/src/client_mqtt.cpp
+++ b/src/client_mqtt.cpp
@@ -24,6 +24,7 @@ void ClientMQTT::begin() {
   
   // Try initial connection
   connectWiFi();
+  lastConnectionAttempt = millis();
 }
 
 void ClientMQTT::loop() {
@@ -58,25 +59,16 @@ bool ClientMQTT::isConnected() {
 }
 
 bool ClientMQTT::connectWiFi() {
+  if (WiFi.status() == WL_CONNECTED) {
+    Serial.printf("WiFi connected! IP: %s\n", WiFi.localIP().toString().c_str());
+    return true;
+  }
+
   Serial.printf("Connecting to WiFi: %s\n", WIFI_SSID);
   
   WiFi.mode(WIFI_STA);
   WiFi.begin(WIFI_SSID, WIFI_PSK);
-  
-  // Wait up to 10 seconds for connection
-  uint32_t startTime = millis();
-  while (WiFi.status() != WL_CONNECTED && millis() - startTime < 10000) {
-    delay(100);
-    Serial.print(".");
-  }
-  
-  if (WiFi.status() == WL_CONNECTED) {
-    Serial.printf("\nWiFi connected! IP: %s\n", WiFi.localIP().toString().c_str());
-    return true;
-  } else {
-    Serial.println("\nWiFi connection failed!");
-    return false;
-  }
+  return false;
 }
 
 void ClientMQTT::disconnectWiFi() {

--- a/src/game_manager.cpp
+++ b/src/game_manager.cpp
@@ -8,7 +8,7 @@ ButtonHandler* buttonHandler = nullptr;
 GameManager* gameManager = nullptr;
 
 // ButtonHandler Implementation
-ButtonHandler::ButtonHandler(Bounce& btn) : button(btn), lastButtonPress(0), buttonHeld(false) {
+ButtonHandler::ButtonHandler(Bounce& btn) : button(btn), lastButtonPress(0), buttonHeld(false), longTriggered(false) {
 }
 
 ButtonPress ButtonHandler::checkButtonPress() {
@@ -18,28 +18,30 @@ ButtonPress ButtonHandler::checkButtonPress() {
   if (button.fell()) {
     lastButtonPress = millis();
     buttonHeld = false;
+    longTriggered = false;
     return ButtonPress::NONE;
   }
   
   // Button held - check for long press
-  if (button.read() == LOW && lastButtonPress && !buttonHeld) {
+  if (button.read() == LOW && lastButtonPress) {
     uint32_t holdTime = millis() - lastButtonPress;
     
-    if (holdTime >= VERY_LONG_PRESS_MS) {
+    if (holdTime >= VERY_LONG_PRESS_MS && !buttonHeld) {
       buttonHeld = true;
       return ButtonPress::VERY_LONG;
-    } else if (holdTime >= LONG_PRESS_MS) {
-      buttonHeld = true;
+    } else if (holdTime >= LONG_PRESS_MS && !longTriggered) {
+      longTriggered = true;
       return ButtonPress::LONG;
     }
   }
-  
+
   // Button released
   if (button.rose()) {
     if (!buttonHeld && lastButtonPress) {
       uint32_t pressTime = millis() - lastButtonPress;
       lastButtonPress = 0;
       buttonHeld = false;
+      longTriggered = false;
       
       if (pressTime < SHORT_PRESS_MAX_MS) {
         return ButtonPress::SHORT;
@@ -47,6 +49,7 @@ ButtonPress ButtonHandler::checkButtonPress() {
     }
     lastButtonPress = 0;
     buttonHeld = false;
+    longTriggered = false;
   }
   
   return ButtonPress::NONE;
@@ -73,8 +76,10 @@ void GameManager::handleButtonPress(ButtonPress press) {
       Serial.println("LONG press detected");
       if (currentPhase == Phase::ANSWER) {
         correctAnswer();
-      } else {
+      } else if (currentPhase != Phase::LOBBY) {
         resetGame();
+      } else {
+        Serial.println("LONG press ignored in LOBBY (hold for VERY LONG)");
       }
       break;
       

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -47,7 +47,7 @@ float readBatteryVoltage() {
 
 uint8_t batteryPercentFromVoltage(float vbat) {
   if (vbat >= BATTERY_TABLE[0].voltage) return 100;
-  if (vbat <= BATTERY_TABLE[10].voltage) return 0;
+  if (vbat <= BATTERY_TABLE[10].voltage) return 1;
 
   for (uint8_t i = 0; i < 10; i++) {
     const BatteryPoint high = BATTERY_TABLE[i];
@@ -57,7 +57,7 @@ uint8_t batteryPercentFromVoltage(float vbat) {
       return static_cast<uint8_t>(low.percent + t * (high.percent - low.percent));
     }
   }
-  return 0;
+  return 1;
 }
 
 Rgb batteryColor(uint8_t percent) {

--- a/src/server_main.cpp
+++ b/src/server_main.cpp
@@ -13,6 +13,86 @@
 Adafruit_NeoPixel strip(LED_COUNT, LED_PIN, NEO_GRB + NEO_KHZ800);
 Bounce button = Bounce();
 
+namespace {
+struct BatteryPoint {
+  float voltage;
+  uint8_t percent;
+};
+
+constexpr uint8_t BATTERY_ADC_PIN = 34;
+constexpr float BATTERY_DIVIDER_R1_OHM = 100000.0f; // BAT+ -> ADC
+constexpr float BATTERY_DIVIDER_R2_OHM = 100000.0f; // ADC -> GND
+constexpr uint8_t BATTERY_SAMPLE_COUNT = 16;
+constexpr uint16_t BATTERY_DISPLAY_MS = 3000;
+
+constexpr BatteryPoint BATTERY_TABLE[] = {
+  {4.20f, 100}, {4.10f, 90}, {4.00f, 80}, {3.92f, 70}, {3.85f, 60},
+  {3.79f, 50},  {3.73f, 40}, {3.68f, 30}, {3.60f, 20}, {3.45f, 10}, {3.30f, 0}
+};
+
+bool batteryDisplayActive = false;
+uint32_t batteryDisplayUntil = 0;
+ButtonPress deferredPress = ButtonPress::NONE;
+
+float readBatteryVoltage() {
+  uint32_t sumMilliVolts = 0;
+  for (uint8_t i = 0; i < BATTERY_SAMPLE_COUNT; i++) {
+    sumMilliVolts += analogReadMilliVolts(BATTERY_ADC_PIN);
+    delay(2);
+  }
+
+  const float adcVolts = (sumMilliVolts / static_cast<float>(BATTERY_SAMPLE_COUNT)) / 1000.0f;
+  return adcVolts * ((BATTERY_DIVIDER_R1_OHM + BATTERY_DIVIDER_R2_OHM) / BATTERY_DIVIDER_R2_OHM);
+}
+
+uint8_t batteryPercentFromVoltage(float vbat) {
+  if (vbat >= BATTERY_TABLE[0].voltage) return 100;
+  if (vbat <= BATTERY_TABLE[10].voltage) return 0;
+
+  for (uint8_t i = 0; i < 10; i++) {
+    const BatteryPoint high = BATTERY_TABLE[i];
+    const BatteryPoint low = BATTERY_TABLE[i + 1];
+    if (vbat <= high.voltage && vbat >= low.voltage) {
+      const float t = (vbat - low.voltage) / (high.voltage - low.voltage);
+      return static_cast<uint8_t>(low.percent + t * (high.percent - low.percent));
+    }
+  }
+  return 0;
+}
+
+Rgb batteryColor(uint8_t percent) {
+  if (percent < 20) return Rgb(255, 0, 0);
+  if (percent < 50) return Rgb(255, 180, 0);
+  return Rgb(0, 255, 0);
+}
+
+void showBatteryOnRing(uint8_t percent) {
+  if (!ledController) return;
+
+  const Rgb base = batteryColor(percent);
+  const float ledUnits = (percent / 100.0f) * 8.0f;
+  const uint8_t fullLeds = static_cast<uint8_t>(ledUnits);
+  const float fraction = ledUnits - fullLeds;
+
+  for (uint8_t i = 0; i < LED_COUNT; i++) {
+    ledController->setPixelColor(i, COLOR_BLACK);
+  }
+
+  for (uint8_t i = 0; i < 8; i++) {
+    if (i < fullLeds) {
+      ledController->setPixelColor(i, base);
+    } else if (i == fullLeds && fraction > 0.0f) {
+      ledController->setPixelColor(i, Rgb(
+        static_cast<uint8_t>(base.r * fraction),
+        static_cast<uint8_t>(base.g * fraction),
+        static_cast<uint8_t>(base.b * fraction)
+      ));
+    }
+  }
+  ledController->showLEDs();
+}
+} // namespace
+
 void setup() {
   Serial.begin(115200);
   Serial.println("ESP32 Quiz-Buzzer Server Starting...");
@@ -24,6 +104,8 @@ void setup() {
   strip.setBrightness(LED_BRIGHTNESS);
   strip.clear();
   strip.show();
+  analogReadResolution(12);
+  analogSetPinAttenuation(BATTERY_ADC_PIN, ADC_11db);
   
   // Initialize LED Controller
   ledController = new LEDController(strip);
@@ -80,7 +162,7 @@ void setup() {
   Serial.println("Phase Controls:");
   Serial.println("- SHORT press: LOBBY -> READY -> OPEN -> NEXT");
   Serial.println("- LONG press: Correct Answer / Reset");
-  Serial.println("- VERY LONG press: Unlock game");
+  Serial.println("- VERY LONG press: Show battery 3s, then unlock game");
   Serial.println("Server ready for client connections!");
 }
 
@@ -92,13 +174,33 @@ void loop() {
   if (buttonHandler) {
     ButtonPress press = buttonHandler->checkButtonPress();
     if (press != ButtonPress::NONE && gameManager) {
-      gameManager->handleButtonPress(press);
+      if (press == ButtonPress::VERY_LONG && currentPhase == Phase::LOBBY) {
+        const float vbat = readBatteryVoltage();
+        const uint8_t percent = batteryPercentFromVoltage(vbat);
+        Serial.printf("Battery check before VERY_LONG action: %.2fV -> %u%%\n", vbat, percent);
+        showBatteryOnRing(percent);
+        batteryDisplayActive = true;
+        batteryDisplayUntil = millis() + BATTERY_DISPLAY_MS;
+        deferredPress = ButtonPress::VERY_LONG;
+      } else {
+        gameManager->handleButtonPress(press);
+      }
     }
   }
   
   // Handle game phases
   if (gameManager) {
-    gameManager->handlePhase();
+    if (batteryDisplayActive) {
+      if (millis() >= batteryDisplayUntil) {
+        batteryDisplayActive = false;
+        if (deferredPress != ButtonPress::NONE) {
+          gameManager->handleButtonPress(deferredPress);
+          deferredPress = ButtonPress::NONE;
+        }
+      }
+    } else {
+      gameManager->handlePhase();
+    }
     gameManager->sendPingToAllClients(); // Background ping system
   }
   


### PR DESCRIPTION
## Summary
This PR adds a battery level display for both server and client devices using the LED ring, with explicit state gating to avoid collisions with gameplay and animations.

The goal is to provide a safe, predictable, non-disruptive battery check flow.

Additionally, this PR makes client WiFi connection handling non-blocking to keep button handling responsive during connection attempts.

## Why this is needed
During live quiz sessions, users need a quick battery check without opening the case or attaching external measurement tools.
At the same time, battery display must not interfere with:
- buzz timing
- answer/decision flow
- lobby reset behavior
- reconnect/disconnected animations

A non-blocking WiFi connect flow is also needed so long-press battery checks are still reliable while the client is trying to connect.

## Hardware assumptions
Battery voltage is measured via ADC using a resistor divider:
- ADC pin: `GPIO34`
- Divider: `100k` (BAT+ -> ADC) and `100k` (ADC -> GND)
- Recommended (optional): `100nF` capacitor from ADC to GND for smoothing

Software-side:
- 12-bit ADC resolution
- `ADC_11db` attenuation
- multi-sample averaging for better stability

## Display behavior
The LED ring is used as battery gauge:
- `8 LEDs = 0..100%`
- Partial LED dimming for fractional 12.5% steps
- Color zones:
  - low: red
  - medium: orange
  - high: green

Display duration:
- fixed `3 seconds`

Minimum feedback safeguard:
- Battery output is clamped to at least `1%` (client + server), ensuring visible feedback even at very low measured voltage.

## Trigger and state rules

### Client
Trigger:
- `VERY_LONG` press (`>= 4s`)

Allowed when:
- client is not connected (WiFi/MQTT not fully connected), or
- game phase is `LOBBY`

Blocked when:
- client is connected and phase is not `LOBBY`

### Server
Trigger:
- `VERY_LONG` press (`>= 4s`) in `LOBBY`

Execution order in `LOBBY`:
1. Show battery for 3 seconds
2. Execute original `VERY_LONG` action afterward (deferred)

Additionally:
- `LONG` press in `LOBBY` is intentionally ignored to avoid overlap with the `VERY_LONG` battery flow.

## Overwrite/conflict prevention
- Client pauses normal animation/state refresh while battery display is active
- Reconnect/status animation does not override battery display during that 3-second window
- Server executes original `VERY_LONG` action only after battery display completes

## Connectivity responsiveness improvement
- Client WiFi connect is now non-blocking (no blocking wait loop during connect attempts)
- This keeps the main loop responsive, especially for button/long-press detection while disconnected or reconnecting
- MQTT retry behavior remains interval-based as before

## Files changed
- `src/client_main.cpp`
- `src/client_manager.cpp`
- `src/client_mqtt.cpp`
- `src/server_main.cpp`
- `src/game_manager.cpp`
- `include/client_manager.h`
- `include/client_mqtt.h`
- `include/game_manager.h`

## Validation
- `platformio run -e client` ✅
- `platformio run -e server` ✅

## Notes
- Percentage mapping is based on a Li-ion voltage curve and may vary with load/cell characteristics.
- For best accuracy and stability, the resistor divider and optional capacitor should match the assumptions above.
