### PR TITLE
Tune player colors 8-10 for better distinction

### DIFF
--- a/include/config.h
+++ b/include/config.h
@@ -64,9 +64,9 @@ constexpr Rgb PLAYER_COLORS[MAX_CLIENTS] = {
   Rgb(255, 0, 255),   // 5. Reines Magenta
   Rgb(0, 255, 255),   // 6. Reines Cyan
   Rgb(255, 128, 0),   // 7. Orange
-  Rgb(128, 0, 255),   // 8. Violett
-  Rgb(255, 192, 203), // 9. Rosa/Pink
-  Rgb(255, 255, 255)  // 10. Weiß
+  Rgb(88, 32, 132),   // 8. Dunkellila
+  Rgb(18, 90, 30),    // 9. Dunkelgruen
+  Rgb(255, 180, 120)  // 10. Warmweiss
 };
 
 // Special Colors


### PR DESCRIPTION
## Summary
This PR refines the player color palette for slots 8-10 to improve visual distinction while keeping the overall look consistent and non-harsh.

## Changes
Updated `PLAYER_COLORS` in `include/config.h`:

- Slot 8: from `Rgb(128, 0, 255)` to `Rgb(88, 32, 132)` (darker purple)
- Slot 9: from `Rgb(255, 192, 203)` to `Rgb(18, 90, 30)` (darker green, less cyan appearance)
- Slot 10: from `Rgb(255, 255, 255)` to `Rgb(255, 180, 120)` (warm white / amber tone)

## Why
Previous colors 9 and 10 could appear too similar or shifted:
- Slot 9 could look too cyan
- Slot 10 still looked close to neutral white

The new values provide:
- clearer distinction
- softer, less harsh appearance
- better harmony with the existing palette

## Scope
- Only color constants changed
- No logic, protocol, timing, or gameplay behavior changes

## Validation
- `platformio run -e client` ✅
- `platformio run -e server` ✅
